### PR TITLE
Fixing itc.peek to return only zero identity and events

### DIFF
--- a/erlang/itc.erl
+++ b/erlang/itc.erl
@@ -24,7 +24,7 @@ fork({I, E}) ->
 {I1, I2} = split(I),
 {{I1, E}, {I2, E}}.
 
-peek({I, E}) -> {{0, E}, {I, E}}.
+peek({_I, E}) -> {0, E}.
 
 event({I, E}) ->
 {I,


### PR DESCRIPTION
Fixing the peek operation so that it can be used in other operations.
Currently it returns the zero identity and the actual identity
which makes the result unusable for other methods.